### PR TITLE
Token must be set after base url in HipChat constructor.

### DIFF
--- a/src/main/java/ch/viascom/hipchat/api/HipChat.java
+++ b/src/main/java/ch/viascom/hipchat/api/HipChat.java
@@ -62,8 +62,8 @@ public class HipChat {
 
 
     public HipChat(String accessToken, String baseUrl) {
-        setAccessToken(accessToken);
         setBaseUrl(baseUrl);
+        setAccessToken(accessToken);
     }
 
     public HipChat setBaseUrl(String baseUrl) {


### PR DESCRIPTION
Otherwise setAccessToken will fail because client not being created yet.